### PR TITLE
Vylepšení autentifikace: 1 dotaz zdarma + refaktoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ CLERK_SECRET_KEY=your_clerk_secret_key_here
 # OPENAI_API_MODEL=
 # GOOGLE_GENERATIVE_AI_API_KEY=
 # ANTHROPIC_API_KEY=
+
+# Groq (OpenAI-compatible, fast inference)
+# GROQ_API_KEY=
+# GROQ_MODEL=llama-3.3-70b-versatile
 # OLLAMA_MODEL=
 # OLLAMA_SUB_MODEL=
 # OLLAMA_BASE_URL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Rocket is an AI-powered search engine with generative UI, forked from [Morphic](https://github.com/miurla/morphic). It streams React components as search results using Vercel AI SDK's RSC (React Server Components) pattern. The UI is in Czech.
+
+## Commands
+
+- `npm run dev` — Start dev server (Next.js with Turbo)
+- `npm run build` — Production build
+- `npm run lint` — ESLint
+- `npm run start` — Start production server
+
+No test framework is configured.
+
+## Architecture
+
+### Core Flow: Server Actions + Generative UI
+
+All AI logic runs through a single server action `submit()` in `app/actions.tsx`. There are no API routes. The flow:
+
+1. User submits query → `submit()` server action called
+2. `taskManager` decides: clarify (inquire) or proceed (search)
+3. If inquire → `inquire` agent generates clarification form
+4. If proceed → `researcher` agent calls tools (search, retrieve, videoSearch) and streams results as React components
+5. If `USE_SPECIFIC_API_FOR_WRITER=true` → `writer` agent generates final answer using a separate model
+6. `querySuggestor` generates related queries
+7. Chat saved to Redis via `saveChat()`
+
+Key concept: **UIState contains React components, AIState contains serializable messages.** The `createAI()` wrapper in `app/actions.tsx` manages both. `onSetAIState` persists to Redis on completion.
+
+### LLM Provider Priority (`lib/utils/index.ts`)
+
+`getModel()` selects provider in this order:
+1. **Groq** (`GROQ_API_KEY`) — uses OpenAI-compatible client, default model `llama-3.3-70b-versatile`
+2. **Ollama** (`OLLAMA_MODEL` + `OLLAMA_BASE_URL`) — local models
+3. **Google Gemini** (`GOOGLE_GENERATIVE_AI_API_KEY`) — `gemini-1.5-pro-latest`
+4. **Anthropic** (`ANTHROPIC_API_KEY`) — `claude-3-5-sonnet-20240620`
+5. **OpenAI** (fallback) — default `gpt-4o`
+
+The writer agent (`lib/agents/writer.tsx`) can use a separate provider via `SPECIFIC_API_BASE/KEY/MODEL` env vars when `USE_SPECIFIC_API_FOR_WRITER=true`.
+
+### Agents (`lib/agents/`)
+
+- `task-manager.tsx` — Decides inquire vs proceed (uses `generateObject` with Zod schema)
+- `inquire.tsx` — Generates clarification questions
+- `researcher.tsx` — Main agent, calls tools and streams results
+- `writer.tsx` — Generates final answer (optional, separate model)
+- `query-suggestor.tsx` — Generates related queries
+
+### Tools (`lib/agents/tools/`)
+
+- `search.tsx` — Tavily API (or Exa) for web search
+- `retrieve.tsx` — Jina Reader API for URL content extraction
+- `video-search.tsx` — Serper API for video search (optional, needs `SERPER_API_KEY`)
+
+### Authentication
+
+Clerk (`@clerk/nextjs`) with middleware in `middleware.ts`. Public routes: `/`, `/sign-in`, `/sign-up`. All other routes are protected. Anonymous users get one free query before being prompted to sign in.
+
+### State Management
+
+- **AI State** (server): `createAI()` from `ai/rsc` — chat messages, chatId
+- **UI State** (client): Streamed React components
+- **App State**: `AppStateContext` in `lib/utils/app-state.tsx` — tracks `isGenerating`
+- **Persistence**: Upstash Redis for chat history
+
+### Key Directories
+
+- `app/` — Next.js App Router pages and the main `actions.tsx` server action
+- `lib/agents/` — AI agent implementations
+- `lib/agents/tools/` — Tool implementations (search, retrieve, video)
+- `lib/actions/chat.ts` — Redis chat persistence
+- `lib/types/` — TypeScript types including `AIMessage`
+- `lib/schema/` — Zod schemas for agent outputs
+- `components/` — React components (mix of server and client)
+- `components/ui/` — shadcn/ui base components
+
+## Code Style
+
+- No semicolons, single quotes (Prettier defaults in the project)
+- Path alias: `@/*` maps to project root
+- shadcn/ui for UI components with Radix primitives
+- `cn()` utility from `lib/utils` for Tailwind class merging
+
+## Environment Variables
+
+Required: `OPENAI_API_KEY` (or another provider key), `TAVILY_API_KEY`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`
+
+See `.env.example` for the full list of optional provider keys and configuration.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,13 +9,7 @@ import { Sidebar } from '@/components/sidebar'
 import { Toaster } from '@/components/ui/sonner'
 import { AppStateProvider } from '@/lib/utils/app-state'
 import RetroGrid from '@/components/RetroGrid'
-import {
-  ClerkProvider,
-  SignInButton,
-  SignedIn,
-  SignedOut,
-  UserButton
-} from '@clerk/nextjs'
+import { ClerkProvider } from '@clerk/nextjs'
 
 const fontSans = FontSans({
   subsets: ['latin'],

--- a/components/followup-panel.tsx
+++ b/components/followup-panel.tsx
@@ -3,40 +3,22 @@
 import { useState } from 'react'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
-import { useActions, useUIState } from 'ai/rsc'
-import type { AI } from '@/app/actions'
-import { UserMessage } from './user-message'
 import { ArrowRight } from 'lucide-react'
-import { useAppState } from '@/lib/utils/app-state'
+import { useMessageSubmit } from '@/lib/hooks/use-message-submit'
+import { useAuth } from '@clerk/nextjs'
 
 export function FollowupPanel() {
   const [input, setInput] = useState('')
-  const { submit } = useActions()
-  const [, setMessages] = useUIState<typeof AI>()
-  const { isGenerating, setIsGenerating } = useAppState()
+  const { isSignedIn } = useAuth()
+  const { submit, isGenerating } = useMessageSubmit(isSignedIn)
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-
     if (isGenerating) return
 
-    setIsGenerating(true)
-    setInput('')
-
     const formData = new FormData(event.currentTarget as HTMLFormElement)
-
-    const userMessage = {
-      id: Date.now(),
-      isGenerating: false,
-      component: <UserMessage message={input} />
-    }
-
-    const responseMessage = await submit(formData)
-    setMessages(currentMessages => [
-      ...currentMessages,
-      userMessage,
-      responseMessage
-    ])
+    setInput('')
+    await submit(input, formData)
   }
 
   return (

--- a/components/search-related.tsx
+++ b/components/search-related.tsx
@@ -3,17 +3,12 @@
 import React, { useEffect, useState } from 'react'
 import { Button } from './ui/button'
 import { ArrowRight } from 'lucide-react'
-import {
-  StreamableValue,
-  useActions,
-  useStreamableValue,
-  useUIState
-} from 'ai/rsc'
-import { AI } from '@/app/actions'
-import { UserMessage } from './user-message'
+import { StreamableValue, useStreamableValue } from 'ai/rsc'
 import { PartialRelated } from '@/lib/schema/related'
 import { Section } from './section'
 import { Skeleton } from './ui/skeleton'
+import { useMessageSubmit } from '@/lib/hooks/use-message-submit'
+import { useAuth } from '@clerk/nextjs'
 
 export interface SearchRelatedProps {
   relatedQueries: StreamableValue<PartialRelated>
@@ -22,8 +17,8 @@ export interface SearchRelatedProps {
 export const SearchRelated: React.FC<SearchRelatedProps> = ({
   relatedQueries
 }) => {
-  const { submit } = useActions()
-  const [, setMessages] = useUIState<typeof AI>()
+  const { isSignedIn } = useAuth()
+  const { submit } = useMessageSubmit(isSignedIn)
   const [data, error, pending] = useStreamableValue(relatedQueries)
   const [related, setRelated] = useState<PartialRelated>()
 
@@ -36,7 +31,6 @@ export const SearchRelated: React.FC<SearchRelatedProps> = ({
     event.preventDefault()
     const formData = new FormData(event.currentTarget as HTMLFormElement)
 
-    // // Get the submitter of the form
     const submitter = (event.nativeEvent as SubmitEvent)
       .submitter as HTMLInputElement
     let query = ''
@@ -45,17 +39,7 @@ export const SearchRelated: React.FC<SearchRelatedProps> = ({
       query = submitter.value
     }
 
-    const userMessage = {
-      id: Date.now(),
-      component: <UserMessage message={query} />
-    }
-
-    const responseMessage = await submit(formData)
-    setMessages(currentMessages => [
-      ...currentMessages,
-      userMessage,
-      responseMessage
-    ])
+    await submit(query, formData)
   }
 
   return related ? (

--- a/lib/agents/researcher.tsx
+++ b/lib/agents/researcher.tsx
@@ -3,6 +3,8 @@ import { CoreMessage, ToolCallPart, ToolResultPart, streamText } from 'ai'
 import { getTools } from './tools'
 import { getModel, transformToolMessages } from '../utils'
 import { AnswerSection } from '@/components/answer-section'
+import { MODEL_CONFIG } from '@/lib/constants'
+import { getProviderConfig } from '@/lib/utils/providers'
 
 export async function researcher(
   uiStream: ReturnType<typeof createStreamableUI>,
@@ -15,10 +17,7 @@ export async function researcher(
 
   // Transform the messages if using Ollama provider
   let processedMessages = messages
-  const useOllamaProvider = !!(
-    process.env.OLLAMA_MODEL && process.env.OLLAMA_BASE_URL
-  )
-  const useAnthropicProvider = !!process.env.ANTHROPIC_API_KEY
+  const { useOllama: useOllamaProvider, useAnthropic: useAnthropicProvider } = getProviderConfig()
   if (useOllamaProvider) {
     processedMessages = transformToolMessages(messages)
   }
@@ -31,7 +30,7 @@ export async function researcher(
   const currentDate = new Date().toLocaleString()
   const result = await streamText({
     model: getModel(useSubModel),
-    maxTokens: 2500,
+    maxTokens: MODEL_CONFIG.MAX_TOKENS,
     system: `As a professional search expert, you possess the ability to search for any information on the web.
     or any information on the web.
     For each user query, utilize the search results to their fullest potential to provide additional information and assistance in your response.

--- a/lib/agents/tools/execute-with-error-handling.ts
+++ b/lib/agents/tools/execute-with-error-handling.ts
@@ -1,0 +1,23 @@
+import { createStreamableUI } from 'ai/rsc'
+import { createStreamableValue } from 'ai/rsc'
+
+interface StreamableToolContext {
+  uiStream: ReturnType<typeof createStreamableUI>
+  streamResults: ReturnType<typeof createStreamableValue<string>>
+  errorMessage: string
+}
+
+export async function executeWithStreamErrorHandling<T>(
+  context: StreamableToolContext,
+  fn: () => Promise<T>
+): Promise<{ result: T | undefined; hasError: boolean }> {
+  try {
+    const result = await fn()
+    return { result, hasError: false }
+  } catch (error) {
+    console.error(context.errorMessage, error)
+    context.uiStream.update(null)
+    context.streamResults.done()
+    return { result: undefined, hasError: true }
+  }
+}

--- a/lib/agents/tools/index.tsx
+++ b/lib/agents/tools/index.tsx
@@ -9,23 +9,13 @@ export interface ToolProps {
 }
 
 export const getTools = ({ uiStream, fullResponse }: ToolProps) => {
-  const tools: any = {
-    search: searchTool({
-      uiStream,
-      fullResponse
-    }),
-    retrieve: retrieveTool({
-      uiStream,
-      fullResponse
-    })
-  }
+  const toolProps = { uiStream, fullResponse }
 
-  if (process.env.SERPER_API_KEY) {
-    tools.videoSearch = videoSearchTool({
-      uiStream,
-      fullResponse
-    })
+  return {
+    search: searchTool(toolProps),
+    retrieve: retrieveTool(toolProps),
+    ...(process.env.SERPER_API_KEY
+      ? { videoSearch: videoSearchTool(toolProps) }
+      : {})
   }
-
-  return tools
 }

--- a/lib/agents/tools/retrieve.tsx
+++ b/lib/agents/tools/retrieve.tsx
@@ -2,6 +2,7 @@ import { tool } from 'ai'
 import { retrieveSchema } from '@/lib/schema/retrieve'
 import { ToolProps } from '.'
 import { SearchSkeleton } from '@/components/search-skeleton'
+import { API_URLS, MODEL_CONFIG } from '@/lib/constants'
 import { SearchResults as SearchResultsType } from '@/lib/types'
 import RetrieveSection from '@/components/retrieve-section'
 
@@ -15,7 +16,7 @@ export const retrieveTool = ({ uiStream, fullResponse }: ToolProps) => tool({
 
     let results: SearchResultsType | undefined
     try {
-      const response = await fetch(`https://r.jina.ai/${url}`, {
+      const response = await fetch(`${API_URLS.JINA_READER}${url}`, {
         method: 'GET',
         headers: {
           Accept: 'application/json',
@@ -27,8 +28,8 @@ export const retrieveTool = ({ uiStream, fullResponse }: ToolProps) => tool({
         hasError = true
       } else {
         // Limit the content to 5000 characters
-        if (json.data.content.length > 5000) {
-          json.data.content = json.data.content.slice(0, 5000)
+        if (json.data.content.length > MODEL_CONFIG.CONTENT_LIMIT) {
+          json.data.content = json.data.content.slice(0, MODEL_CONFIG.CONTENT_LIMIT)
         }
         results = {
           results: [

--- a/lib/agents/tools/video-search.tsx
+++ b/lib/agents/tools/video-search.tsx
@@ -3,45 +3,44 @@ import { createStreamableValue } from 'ai/rsc'
 import { searchSchema } from '@/lib/schema/search'
 import { ToolProps } from '.'
 import { VideoSearchSection } from '@/components/video-search-section'
+import { API_URLS } from '@/lib/constants'
+import { executeWithStreamErrorHandling } from './execute-with-error-handling'
 
-// Start Generation Here
 export const videoSearchTool = ({ uiStream, fullResponse }: ToolProps) => tool({
   description: 'Search for videos from YouTube',
   parameters: searchSchema,
   execute: async ({ query }) => {
-    let hasError = false
-    // Append the search section
     const streamResults = createStreamableValue<string>()
     uiStream.append(<VideoSearchSection result={streamResults.value} />)
 
-    let searchResult
-    try {
-      const response = await fetch('https://google.serper.dev/videos', {
-        method: 'POST',
-        headers: {
-          'X-API-KEY': process.env.SERPER_API_KEY || '',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ q: query })
-      })
-      if (!response.ok) {
-        throw new Error('Network response was not ok')
+    const { result: searchResult, hasError } = await executeWithStreamErrorHandling(
+      {
+        uiStream,
+        streamResults,
+        errorMessage: 'Video Search API error:'
+      },
+      async () => {
+        const response = await fetch(API_URLS.SERPER_VIDEO, {
+          method: 'POST',
+          headers: {
+            'X-API-KEY': process.env.SERPER_API_KEY || '',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ q: query })
+        })
+        if (!response.ok) {
+          throw new Error('Network response was not ok')
+        }
+        return response.json()
       }
-      searchResult = await response.json()
-    } catch (error) {
-      console.error('Video Search API error:', error)
-      hasError = true
-    }
+    )
 
     if (hasError) {
       fullResponse = `An error occurred while searching for videos with "${query}.`
-      uiStream.update(null)
-      streamResults.done()
       return searchResult
     }
 
     streamResults.done(JSON.stringify(searchResult))
-
     return searchResult
   }
 })

--- a/lib/agents/writer.tsx
+++ b/lib/agents/writer.tsx
@@ -3,6 +3,7 @@ import { CoreMessage, streamText } from 'ai'
 import { createOpenAI } from '@ai-sdk/openai'
 import { AnswerSection } from '@/components/answer-section'
 import { AnswerSectionGenerated } from '@/components/answer-section-generated'
+import { MODEL_CONFIG } from '@/lib/constants'
 
 export async function writer(
   uiStream: ReturnType<typeof createStreamableUI>,
@@ -22,7 +23,7 @@ export async function writer(
 
   await streamText({
     model: openai!.chat(process.env.SPECIFIC_API_MODEL || 'llama3-70b-8192'),
-    maxTokens: 2500,
+    maxTokens: MODEL_CONFIG.MAX_TOKENS,
     system: `As a professional writer, your job is to generate a comprehensive and informative, yet concise answer of 400 words or less for the given question based solely on the provided search results (URL and content). You must only use information from the provided search results. Use an unbiased and journalistic tone. Combine search results together into a coherent answer. Do not repeat text. If there are any images relevant to your answer, be sure to include them as well. Aim to directly address the user's question, augmenting your response with insights gleaned from the search results. 
     Whenever quoting or referencing information from a specific URL, always cite the source URL explicitly. Please match the language of the response to the user's language.
     Always answer in Markdown format. Links and images must follow the correct format.

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,33 @@
+export const MESSAGE_TYPES = {
+  ANSWER: 'answer',
+  RELATED: 'related',
+  FOLLOWUP: 'followup',
+  INQUIRY: 'inquiry',
+  TOOL: 'tool',
+  INPUT: 'input',
+  INPUT_RELATED: 'input_related',
+  END: 'end',
+  SKIP: 'skip'
+} as const
+
+export const MODEL_CONFIG = {
+  MAX_TOKENS: 2500,
+  CONTENT_LIMIT: 5000,
+  MAX_MESSAGES_SPECIFIC_API: 5,
+  MAX_MESSAGES_OLLAMA: 1,
+  MAX_MESSAGES_DEFAULT: 10
+} as const
+
+export const API_URLS = {
+  JINA_READER: 'https://r.jina.ai/',
+  TAVILY_SEARCH: 'https://api.tavily.com/search',
+  SERPER_VIDEO: 'https://google.serper.dev/videos',
+  GROQ_BASE: 'https://api.groq.com/openai/v1'
+} as const
+
+export const MODEL_DEFAULTS = {
+  GROQ: 'llama-3.3-70b-versatile',
+  OPENAI: 'gpt-4o',
+  GOOGLE: 'models/gemini-1.5-pro-latest',
+  ANTHROPIC: 'claude-3-5-sonnet-20240620'
+} as const

--- a/lib/hooks/use-message-submit.ts
+++ b/lib/hooks/use-message-submit.ts
@@ -1,0 +1,49 @@
+'use client'
+
+import { useActions, useUIState } from 'ai/rsc'
+import { generateId } from 'ai'
+import type { AI } from '@/app/actions'
+import { useAppState } from '@/lib/utils/app-state'
+import { UserMessage } from '@/components/user-message'
+import { createElement } from 'react'
+import { useQueryGuard } from '@/lib/hooks/use-query-guard'
+
+export function useMessageSubmit(isSignedIn?: boolean) {
+  const { submit } = useActions()
+  const [, setMessages] = useUIState<typeof AI>()
+  const { isGenerating, setIsGenerating } = useAppState()
+  const { guardQuery } = useQueryGuard(isSignedIn)
+
+  async function submitMessage(
+    query: string,
+    formData: FormData,
+    options?: { addUserMessageBeforeSubmit?: boolean }
+  ) {
+    if (!guardQuery()) return
+    const addBefore = options?.addUserMessageBeforeSubmit ?? false
+    setIsGenerating(true)
+
+    const userMessage = {
+      id: generateId(),
+      component: createElement(UserMessage, { message: query })
+    }
+
+    if (addBefore) {
+      setMessages(currentMessages => [...currentMessages, userMessage])
+    }
+
+    const responseMessage = await submit(formData)
+
+    if (addBefore) {
+      setMessages(currentMessages => [...currentMessages, responseMessage])
+    } else {
+      setMessages(currentMessages => [
+        ...currentMessages,
+        userMessage,
+        responseMessage
+      ])
+    }
+  }
+
+  return { submit: submitMessage, isGenerating, setIsGenerating }
+}

--- a/lib/hooks/use-query-guard.ts
+++ b/lib/hooks/use-query-guard.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+const COOKIE_NAME = 'freeQueryUsed'
+
+function getFreeQueryUsed(): boolean {
+  return document.cookie.includes(`${COOKIE_NAME}=true`)
+}
+
+function setFreeQueryUsed(): void {
+  document.cookie = `${COOKIE_NAME}=true; path=/; max-age=86400; SameSite=Lax`
+}
+
+export function useQueryGuard(isSignedIn?: boolean) {
+  const router = useRouter()
+
+  function guardQuery(): boolean {
+    if (isSignedIn) return true
+    if (!getFreeQueryUsed()) {
+      setFreeQueryUsed()
+      return true
+    }
+    router.push('/sign-in')
+    return false
+  }
+
+  return { guardQuery }
+}

--- a/lib/schema/retrieve.tsx
+++ b/lib/schema/retrieve.tsx
@@ -5,4 +5,4 @@ export const retrieveSchema = z.object({
   url: z.string().describe('The url to retrieve')
 })
 
-export type PartialInquiry = DeepPartial<typeof retrieveSchema>
+export type PartialRetrieve = DeepPartial<typeof retrieveSchema>

--- a/lib/schema/search.tsx
+++ b/lib/schema/search.tsx
@@ -21,4 +21,4 @@ export const searchSchema = z.object({
     )
 })
 
-export type PartialInquiry = DeepPartial<typeof searchSchema>
+export type PartialSearch = DeepPartial<typeof searchSchema>

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -19,16 +19,28 @@ export function getModel(useSubModel = false) {
   let openaiApiModel = process.env.OPENAI_API_MODEL || 'gpt-4o'
   const googleApiKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY
+  const groqApiKey = process.env.GROQ_API_KEY
+  const groqModel = process.env.GROQ_MODEL || 'llama-3.3-70b-versatile'
 
   if (
     !(ollamaBaseUrl && ollamaModel) &&
     !openaiApiKey &&
     !googleApiKey &&
-    !anthropicApiKey
+    !anthropicApiKey &&
+    !groqApiKey
   ) {
     throw new Error(
-      'Missing environment variables for Ollama, OpenAI, Google or Anthropic'
+      'Missing environment variables for Ollama, OpenAI, Google, Anthropic or Groq'
     )
+  }
+
+  // Groq (OpenAI-compatible, fast inference)
+  if (groqApiKey) {
+    const groq = createOpenAI({
+      baseURL: 'https://api.groq.com/openai/v1',
+      apiKey: groqApiKey
+    })
+    return groq.chat(groqModel)
   }
   // Ollama
   if (ollamaBaseUrl && ollamaModel) {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -5,6 +5,7 @@ import { createOpenAI } from '@ai-sdk/openai'
 import { google } from '@ai-sdk/google'
 import { anthropic } from '@ai-sdk/anthropic'
 import { CoreMessage } from 'ai'
+import { API_URLS, MODEL_DEFAULTS } from '@/lib/constants'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -16,11 +17,11 @@ export function getModel(useSubModel = false) {
   const ollamaSubModel = process.env.OLLAMA_SUB_MODEL
   const openaiApiBase = process.env.OPENAI_API_BASE
   const openaiApiKey = process.env.OPENAI_API_KEY
-  let openaiApiModel = process.env.OPENAI_API_MODEL || 'gpt-4o'
+  let openaiApiModel = process.env.OPENAI_API_MODEL || MODEL_DEFAULTS.OPENAI
   const googleApiKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY
   const groqApiKey = process.env.GROQ_API_KEY
-  const groqModel = process.env.GROQ_MODEL || 'llama-3.3-70b-versatile'
+  const groqModel = process.env.GROQ_MODEL || MODEL_DEFAULTS.GROQ
 
   if (
     !(ollamaBaseUrl && ollamaModel) &&
@@ -37,7 +38,7 @@ export function getModel(useSubModel = false) {
   // Groq (OpenAI-compatible, fast inference)
   if (groqApiKey) {
     const groq = createOpenAI({
-      baseURL: 'https://api.groq.com/openai/v1',
+      baseURL: API_URLS.GROQ_BASE,
       apiKey: groqApiKey
     })
     return groq.chat(groqModel)
@@ -54,11 +55,11 @@ export function getModel(useSubModel = false) {
   }
 
   if (googleApiKey) {
-    return google('models/gemini-1.5-pro-latest')
+    return google(MODEL_DEFAULTS.GOOGLE)
   }
 
   if (anthropicApiKey) {
-    return anthropic('claude-3-5-sonnet-20240620')
+    return anthropic(MODEL_DEFAULTS.ANTHROPIC)
   }
 
   // Fallback to OpenAI instead

--- a/lib/utils/providers.ts
+++ b/lib/utils/providers.ts
@@ -1,0 +1,9 @@
+export function getProviderConfig() {
+  return {
+    useOllama: !!(process.env.OLLAMA_MODEL && process.env.OLLAMA_BASE_URL),
+    useGoogle: !!process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+    useAnthropic: !!process.env.ANTHROPIC_API_KEY,
+    useGroq: !!process.env.GROQ_API_KEY,
+    useSpecificAPI: process.env.USE_SPECIFIC_API_FOR_WRITER === 'true'
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,12 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
 
-const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)', '/']);
+const isPublicRoute = createRouteMatcher([
+  '/sign-in(.*)',
+  '/sign-up(.*)',
+  '/',
+  '/search(.*)',
+  '/share(.*)'
+]);
 
 export default clerkMiddleware((auth, request) => {
   if (!isPublicRoute(request)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -506,11 +506,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.8",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -652,21 +651,28 @@
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.0",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -840,13 +846,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.15.tgz",
-      "integrity": "sha512-S1qaj25Wru2dUpcIZMjxeMVSwkt8BK4dmWHHiBuRstcIyOsMapqT4A4jSB6onvqeygkSSmOkyny9VVx8JIGamQ==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.5",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.35.tgz",
+      "integrity": "sha512-Jw9A3ICz2183qSsqwi7fgq4SBPiNfmOLmTPXKvlnzstUwyvBrtySiY+8RXJweNAs9KThb1+bYhZh9XWcNOr2zQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -854,9 +862,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.15.tgz",
-      "integrity": "sha512-Rvh7KU9hOUBnZ9TJ28n2Oa7dD9cvDBKua9IKx7cfQQ0GoYUwg9ig31O2oMwH3wm+pE3IkAQ67ZobPfEgurPZIA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
       "cpu": [
         "arm64"
       ],
@@ -870,9 +878,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.15.tgz",
-      "integrity": "sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
       "cpu": [
         "x64"
       ],
@@ -886,9 +894,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.15.tgz",
-      "integrity": "sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
       "cpu": [
         "arm64"
       ],
@@ -902,9 +910,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.15.tgz",
-      "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
       ],
@@ -918,9 +926,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.15.tgz",
-      "integrity": "sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
       "cpu": [
         "x64"
       ],
@@ -934,9 +942,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.15.tgz",
-      "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
       ],
@@ -950,9 +958,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.15.tgz",
-      "integrity": "sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
       "cpu": [
         "arm64"
       ],
@@ -966,9 +974,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
-      "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
       "cpu": [
         "ia32"
       ],
@@ -982,9 +990,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.15.tgz",
-      "integrity": "sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
       "cpu": [
         "x64"
       ],
@@ -1939,55 +1947,160 @@
       "version": "3.0.2",
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "7.2.0",
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.54.0.tgz",
+      "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.2.0",
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/typescript-estree": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
-        "debug": "^4.3.4"
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.54.0",
+        "@typescript-eslint/type-utils": "8.54.0",
+        "@typescript-eslint/utils": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@typescript-eslint/parser": "^8.54.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.2.0",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
+      "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0"
+        "@typescript-eslint/scope-manager": "8.54.0",
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/typescript-estree": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0",
+        "debug": "^4.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.54.0.tgz",
+      "integrity": "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.54.0",
+        "@typescript-eslint/types": "^8.54.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.54.0.tgz",
+      "integrity": "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/types": {
-      "version": "7.2.0",
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.54.0.tgz",
+      "integrity": "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.54.0.tgz",
+      "integrity": "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/typescript-estree": "8.54.0",
+        "@typescript-eslint/utils": "8.54.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
+      "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1995,34 +2108,47 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.2.0",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.54.0.tgz",
+      "integrity": "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "@typescript-eslint/project-service": "8.54.0",
+        "@typescript-eslint/tsconfig-utils": "8.54.0",
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2035,16 +2161,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.6.2",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2054,20 +2174,59 @@
         "node": ">=10"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.2.0",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.54.0.tgz",
+      "integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.54.0",
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/typescript-estree": "8.54.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz",
+      "integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.54.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -2418,14 +2577,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
       "dev": true,
@@ -2603,7 +2754,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2932,10 +3085,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.5",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -3054,17 +3209,6 @@
     "node_modules/diff-match-patch": {
       "version": "1.0.5",
       "license": "Apache-2.0"
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -3378,13 +3522,16 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.2.5",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.35.tgz",
+      "integrity": "sha512-BpLsv01UisH193WyT/1lpHqq5iJ/Orfz9h/NOOlAmTUq4GY349PextQ62K4XpnaM9supeiEn3TaOTeQO07gURg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "14.2.5",
+        "@next/eslint-plugin-next": "14.2.35",
         "@rushstack/eslint-patch": "^1.3.3",
-        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0",
+        "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.28.1",
@@ -4004,6 +4151,15 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
       "version": "9.0.5",
       "license": "ISC",
@@ -4015,13 +4171,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/globals": {
@@ -4051,25 +4200,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -4865,7 +4995,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4945,7 +5077,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.11",
+      "version": "0.16.28",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
+      "integrity": "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -5326,7 +5460,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -5944,7 +6080,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -5980,12 +6118,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.15.tgz",
-      "integrity": "sha512-h9ctmOokpoDphRvMGnwOJAedT6zKhwqyZML9mDtspgf4Rh3Pn7UTYKqePNoDvhsWBAO5GoPNYshnAUGIazVGmw==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.15",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -6000,15 +6138,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.15",
-        "@next/swc-darwin-x64": "14.2.15",
-        "@next/swc-linux-arm64-gnu": "14.2.15",
-        "@next/swc-linux-arm64-musl": "14.2.15",
-        "@next/swc-linux-x64-gnu": "14.2.15",
-        "@next/swc-linux-x64-musl": "14.2.15",
-        "@next/swc-win32-arm64-msvc": "14.2.15",
-        "@next/swc-win32-ia32-msvc": "14.2.15",
-        "@next/swc-win32-x64-msvc": "14.2.15"
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -6382,14 +6520,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/picocolors": {
@@ -6791,10 +6921,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "license": "MIT"
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
       "dev": true,
@@ -7140,14 +7266,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/snake-case": {
@@ -7682,6 +7800,54 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "license": "MIT",
@@ -7713,14 +7879,16 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.3.0",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-interface-checker": {


### PR DESCRIPTION
## Summary
- **Cookie-based auth guard** — nepřihlášení uživatelé dostanou 1 dotaz zdarma, poté redirect na přihlášení (cookie `freeQueryUsed`, 24h platnost)
- **Veřejné routes** — `/search(.*)` a `/share(.*)` nyní nevyžadují přihlášení, takže prohlížení výsledků funguje i po refreshi
- **Konzistentní ochrana** — auth guard je v sdíleném `useMessageSubmit` hooku, chrání chat-panel, followup-panel i search-related jednotně
- **Refaktoring** — extrakce konstant, centralizace provider konfigurace, sdílený error handling pro tools, dekompozice actions.tsx

## Changes
| Soubor | Změna |
|--------|-------|
| `middleware.ts` | Přidány `/search(.*)`, `/share(.*)` do veřejných routes |
| `lib/hooks/use-query-guard.ts` | **Nový** — cookie-based guard hook |
| `lib/hooks/use-message-submit.ts` | **Nový** — sdílený submit hook s auth guardem |
| `lib/constants.ts` | **Nový** — centralizované konstanty |
| `lib/utils/providers.ts` | **Nový** — centralizovaná provider konfigurace |
| `lib/agents/tools/execute-with-error-handling.ts` | **Nový** — sdílený error handling wrapper |
| `components/chat-panel.tsx` | Odstraněna `isFirstMessage` state logika, používá sdílený hook |
| `components/followup-panel.tsx` | Přidán `useAuth()` + sdílený hook |
| `components/search-related.tsx` | Přidán `useAuth()` + sdílený hook |
| `app/actions.tsx` | Dekompozice na helper funkce |
| `CLAUDE.md` | Dokumentace projektu pro Claude Code |

## Test plan
- [ ] Nepřihlášený uživatel → první dotaz projde → cookie se nastaví
- [ ] Nepřihlášený → druhý dotaz (nebo followup/related) → redirect na `/sign-in`
- [ ] Refresh na `/search/{id}` → stránka se načte bez vynucení přihlášení
- [ ] Nepřihlášený po refreshi → pokus o dotaz → redirect (cookie přežila)
- [ ] Přihlášený uživatel → vše funguje bez omezení
- [ ] `npm run build` + `npm run lint` prochází bez chyb

🤖 Generated with [Claude Code](https://claude.com/claude-code)